### PR TITLE
fix the url which was edited during the handover

### DIFF
--- a/src/main/java/nz/govt/linz/AdminBoundaries/UserAdmin/UserReaderAIMS.java
+++ b/src/main/java/nz/govt/linz/AdminBoundaries/UserAdmin/UserReaderAIMS.java
@@ -36,8 +36,7 @@ public class UserReaderAIMS extends UserReader {
 	
 	private static final Logger LOGGER = Logger.getLogger(UserReaderAIMS.class.getName());
 	
-	//public static final String user_ref_base = "http://<SVR>:8080/aims/api/admin/users";
-	public static final String user_ref_base = "https://<SVR>:8443/aims/api/admin/users";
+	public static final String user_ref_base = "http://<SVR>:8080/aims/api/admin/users";
 	
 	/** Simple pair class for actions put/post and their json payloads */
 	class ActionPayload {


### PR DESCRIPTION
The UserAdmin interface (https://prdassgeo03:8443/ab/usr) was failing because of one of the changes during the handover. the PR is to revert this change.